### PR TITLE
Lowercase payment URL hostname

### DIFF
--- a/src/components/SignUp/registration.js
+++ b/src/components/SignUp/registration.js
@@ -24,7 +24,7 @@ const validationSchema = Yup.object().shape({
     .test('validPaymentLink', '', function(value) {
       if (!value) return false;
 
-      const hostname = value.split('/')[2];
+      const hostname = value.split('/')[2].toLowerCase();
       const path = value.split('/')[3];
 
       const [regex, errMsg] = (function(hostname) {


### PR DESCRIPTION
This should fix the issue with the lowercase vs. non-lowercased hostnames in the URLs. Don't want to to lowercase the whole string in case there's some validation logic later that is case sensitive in the the path and query components. 