### PR TITLE
80a entries subcollection

### DIFF
--- a/src/components/Distribute/index.js
+++ b/src/components/Distribute/index.js
@@ -58,7 +58,10 @@ class DistributeTableBase extends Component {
 		const { fieldValue, entriesCollection } = this.props.firebase;
 		const docRef = entriesCollection.doc(docId)
 		try {
-			await docRef.update({shown: fieldValue.increment(1)})
+			await docRef.update({
+				shown: fieldValue.increment(1),
+				random: Math.floor(Math.random() * Number.MAX_SAFE_INTEGER),
+			})
 		} catch (e) {
 			console.log(e.message)
 		}

--- a/src/components/Distribute/index.js
+++ b/src/components/Distribute/index.js
@@ -8,7 +8,7 @@ import FooterNav from '../FooterNav';
 
 const DistributePage = () => (
 	<div className="wrapper">
-		<Header /> 		
+		<Header />
 		<DistributeTable />
 		<FooterNav />
 	</div>
@@ -30,7 +30,7 @@ class DistributeTableBase extends Component {
 	async getEntries() {
 		let entries = [];
 		const { entriesCollection } = this.props.firebase;
-		const random = entriesCollection.doc().id;
+		const random = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
 		try {
 			await entriesCollection
 				.where("random", ">=", random)
@@ -40,7 +40,7 @@ class DistributeTableBase extends Component {
 				.then((querySnapshot) => {
 					querySnapshot.forEach((doc) => {
 						entries.push(doc.data());
-						this.updateShownCount(doc.data().random)
+						this.updateShownCount(doc.id)
 					})
 					if (entries) {
 						this.setState({

--- a/src/components/Firebase/firebase.js
+++ b/src/components/Firebase/firebase.js
@@ -59,7 +59,6 @@ class Firebase {
     this.logEvent = app.analytics().logEvent;
     this.userCollection = this.dbFs.collection('users');
     this.entriesCollection = this.dbFs.collection('entries');
-    this.entriesIndexCollection = this.dbFs.collection('entriesIndex');
     this.resourcesCollection = this.dbFs.collection('resources');
     this.miscCollection = this.dbFs.collection('misc');
   }

--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -20,10 +20,19 @@ class HomeLandingBase extends Component {
     lastUpvote: ''
   }
 
-  	componentDidMount() {
-      document.title = "leveler"
-      this.getLastUpdates()
-    }
+  async componentDidMount() {
+    document.title = "leveler"
+    this.getEntryCount();
+    this.getLastUpdates()
+	}
+
+	async getEntryCount() {
+		await this.props.firebase.entriesCollection.get().then(snap => {
+			this.setState({
+				entryCount: snap.size
+			})
+		})
+	}
 
   render() {
     const { lastContrib, lastSignup, lastUpvote } = this.state;

--- a/src/components/SignUp/registration.js
+++ b/src/components/SignUp/registration.js
@@ -62,11 +62,6 @@ const Registration = (props) => {
     setIsOpen(false);
   };
 
-  // ADD ENTRY TO entriesIndex UPON SUBMISSION
-  const addToEntriesIndex = (entriesIndexPayload, entriesIndexCollection) => {
-    const { id } = entriesIndexCollection.doc();
-    entriesIndexCollection.doc(id).set(entriesIndexPayload);
-  };
 
   const updateLastSignup = async (updated) => {
     const { miscCollection } = props.firebase;
@@ -85,28 +80,26 @@ const Registration = (props) => {
       delete values.other_industry;
     }
     values.payment = addURLScheme(values.payment);
-    const { fieldValue, entriesCollection, entriesIndexCollection } = props.firebase;
-    const random = entriesCollection.doc().id;
-    const entriesCollectionPayload = {
-      location: values.location.trim(),
-      industry: values.industry.trim(),
-      description: values.description.trim(),
-      payment_url: [values.payment],
-      suggestion: values.suggestion.trim(),
-      random,
-      created: fieldValue.serverTimestamp(),
-    };
-    const entriesIndexPayload = {
-      parent_id: random,
-      email: values.email.trim(),
-      social_url: values.social_url.trim(),
-      shown: 0,
-      potential_contrib: 0,
-      created: fieldValue.serverTimestamp(),
-    };
-    entriesCollection.doc(random).set(entriesCollectionPayload).then(() => {
-      addToEntriesIndex(entriesIndexPayload, entriesIndexCollection);
-    });
+    const { entriesCollection } = props.firebase;
+
+    entriesCollection
+      .add({
+        location: values.location.trim(),
+        industry: values.industry.trim(),
+        description: values.description.trim(),
+        payment_url: [values.payment],
+        suggestion: values.suggestion.trim(),
+        shown: 0,
+        potential_contrib: 0,
+        random: Math.floor(Math.random() * Number.MAX_SAFE_INTEGER),
+      })
+      .then((docRef) => {
+        docRef.collection('private').add({
+          email: values.email.trim(),
+          social_url: values.social_url.trim(),
+        });
+      });
+
     updateLastSignup(fieldValue.serverTimestamp());
     resetForm({});
     setSubmitted(true);

--- a/src/components/SignUp/registration.js
+++ b/src/components/SignUp/registration.js
@@ -80,7 +80,7 @@ const Registration = (props) => {
       delete values.other_industry;
     }
     values.payment = addURLScheme(values.payment);
-    const { entriesCollection } = props.firebase;
+    const { entriesCollection, fieldValue } = props.firebase;
 
     entriesCollection
       .add({


### PR DESCRIPTION
This PR is just one part of closing issue #80, addressing the following:

- private data is now stored in a `private` subcollection under `/entries` instead of a separate collection (previously `/entriesIndex`)
- `entryCount()` uses the count from the `/entries` collection instead of the now deprecated `/entriesIndex` collection
- the `random` field in `/entries` now uses a random int (in the range 0 to 2**53 - 1) instead of the document id, this is more natural. Implements https://stackoverflow.com/a/46801925/4017850

Before this PR can be merged I need to reset the `random` field for `/entries` in the production DB. 