### PR TITLE
Make email string lowercase when writing to Firestore

### DIFF
--- a/src/components/SignUp/registration.js
+++ b/src/components/SignUp/registration.js
@@ -99,7 +99,7 @@ const Registration = (props) => {
         random: Math.floor(Math.random() * Number.MAX_SAFE_INTEGER),
       })
       .set(privateRef, {
-        email: values.email.trim(),
+        email: values.email.trim().toLowerCase(),
         social_url: values.social_url.trim(),
       })
       .commit()


### PR DESCRIPTION
Resolves #111 