### PR TITLE
Add group field with value 'leveler' in registration

### DIFF
--- a/src/components/SignUp/registration.js
+++ b/src/components/SignUp/registration.js
@@ -101,6 +101,7 @@ const Registration = (props) => {
         suggestion: values.suggestion.trim(),
         shown: 0,
         potential_contrib: 0,
+        group: 'leveler',
         random: Math.floor(Math.random() * Number.MAX_SAFE_INTEGER),
       })
       .set(privateRef, {


### PR DESCRIPTION
This PR is currently just a draft, some questions:

1. The value of the `group` field is constant for each flavor of leveler, where should the value live? An environment variable, or some file of constants?
1. What should the name of the 'main' leveler group be? Right now using 'leveler', but subject to change.

Addresses #128 and #127 